### PR TITLE
Add S3 example using server-side encryption

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -120,6 +120,19 @@ amazon:
   bucket: ""
 ```
 
+Optionally provide a Hash of upload options:
+
+```yaml
+amazon:
+  service: S3
+  access_key_id: ""
+  secret_access_key: ""
+  region: ""
+  bucket: ""
+  upload: 
+    server_side_encryption: "" # 'aws:kms' or 'AES256'
+```
+
 Add the [`aws-sdk-s3`](https://github.com/aws/aws-sdk-ruby) gem to your `Gemfile`:
 
 ```ruby


### PR DESCRIPTION
### Summary

This PR adds an example of using server-side encryption with AWS S3.
